### PR TITLE
Always cleanup the pending modal promise

### DIFF
--- a/src/popeye.coffee
+++ b/src/popeye.coffee
@@ -136,8 +136,10 @@ popeye = (angular) ->
                     $animate.enter(@container, body, bodyLastChild).then =>
                       currentModal = @
                       @openedDeferred.resolve(@)
-            , (error) =>
+            .catch (error) =>
               @handleError(error)
+            .finally ->
+              pendingPromise = null
             return @opened
 
           # Remove the modal container from the DOM via $animate

--- a/test/popeye.spec.coffee
+++ b/test/popeye.spec.coffee
@@ -328,6 +328,25 @@ describe "pathgather.popeye", ->
           expect(oldModalClosed).toBe(true)
           expect(newModalOpened).toBe(true)
 
+      describe "when a previous modal open failed", ->
+        beforeEach ->
+          @modal = @Popeye.openModal(
+            templateUrl: "modal_template.html"
+            resolve: { data: => @$q.reject("Oh no!") }
+          )
+          error = false
+          @modal.opened.catch -> error = true
+          @$rootScope.$digest()
+          expect(error).toBe(true)
+
+        it "cleans up the shared state, and the next open succeeds", ->
+          newModal = @Popeye.openModal(templateUrl: "modal_template.html")
+          newModalOpened = false
+          newModal.opened.then -> newModalOpened = true
+          expect(newModalOpened).toBe(false)
+          @$animate.flush()
+          expect(newModalOpened).toBe(true)
+
       describe "when opening multiple modals in series", ->
         it "opens them in calling order, after closing the previous first", ->
           modal1 = @Popeye.openModal(templateUrl: "modal_template.html", id: "modal1")


### PR DESCRIPTION
This shared state was getting "stuck" if a modal open failed, which prevented subsequent modal opens from succeeding.
This change simply cleans up the existing promise after it resolves or fails.
